### PR TITLE
support testing on arm64 (ubuntu based image)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,16 +30,16 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
+          queries: +security-extended
           languages: ${{ matrix.language }}
+          build-mode: manual
 
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Run
-        run: ./gradlew -x clean jar test
+      - name: Run build
+        run: |
+          chmod +x gradlew
+          ./gradlew -x clean jar test
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{matrix.language}}"
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
 
@@ -36,10 +36,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - run: |
-          ./gradlew -x test clean jar
+      - name: Run
+        run: ./gradlew -x clean jar test
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,6 +7,10 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
@@ -35,22 +35,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
-#      - name: Autobuild
-#        uses: github/codeql-action/autobuild@v1
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
       - run: |
           ./gradlew -x test clean jar
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  security-events: read
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  security-events: read
+  security-events: write
 
 jobs:
   analyze:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run build
         run: |
           chmod +x gradlew
-          ./gradlew -x clean jar test
+          ./gradlew -x test clean jar
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/build.gradle
+++ b/build.gradle
@@ -38,16 +38,15 @@ ext {
          junit5: "6.0.1",
          junitJupiter: "6.0.1",
          testContainers: "1.21.3",
-    		 assertJ: "3.27.6",
-         dnsjava: "3.6.0",
+    	 assertJ: "3.27.6",
+         dnsjava: "3.6.3",
     ]
 }
 dependencies {
 
     // 1. dnsjava
-    compileOnly "dnsjava:dnsjava:${versions.dnsjava}"
-    testImplementation "dnsjava:dnsjava:${versions.dnsjava}"
-
+    implementation("dnsjava:dnsjava:${versions.dnsjava}")
+    testImplementation("dnsjava:dnsjava:${versions.dnsjava}")
     // 2. Apache Spark (spark-sql, spark-core)
     compileOnly "org.apache.spark:spark-sql_2.12:${versions.spark}"
     compileOnly "org.apache.spark:spark-core_2.12:${versions.spark}"

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,8 @@ ext {
          lombok: "1.18.42",
          junit5: "6.0.1",
          junitJupiter: "6.0.1",
-         testContainers: "1.21.3",
+         testContainers: "2.0.2",
+         testContainersJupiter: "1.21.3",
     	 assertJ: "3.27.6",
          dnsjava: "3.6.3",
     ]
@@ -75,5 +76,5 @@ dependencies {
 
     // 6. TestContainers
     testImplementation "org.testcontainers:testcontainers:${versions.testContainers}"
-    testImplementation "org.testcontainers:junit-jupiter:${versions.testContainers}"
+    testImplementation "org.testcontainers:junit-jupiter:${versions.testContainersJupiter}"
 }

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -48,9 +48,9 @@ public class BindContainerFactory {
      */
     private static @NotNull List<String> createPortBindings(final int port) {
         return Arrays.asList(
-                // UDP: 5353:53/udp
+                // UDP: <external>:53/udp
                 String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.UDP),
-                // TCP: 5353:53/tcp
+                // TCP: <external>:53/tcp
                 String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.TCP)
         );
     }

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -57,10 +57,10 @@ public class BindContainerFactory {
 
     @SneakyThrows
     public void stop(GenericContainer<?> container) {
-        if (log.isTraceEnabled()) {
-            log.info("Container logs: {}", container.getLogs());
-        }
         if (container != null) {
+            if (log.isTraceEnabled()) {
+                log.info("Container logs: {}", container.getLogs());
+            }
             container.stop();
         }
         deleteBindJournal();

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -24,8 +24,7 @@ public class BindContainerFactory {
     public GenericContainer<?> create() {
 
         final ImageFromDockerfile image = new ImageFromDockerfile("custom-bind-image")
-                .withFileFromPath(".", DOCKERFILE_DIR)
-                .withFileFromPath("Dockerfile", DOCKERFILE_DIR.resolve("Dockerfile"));
+                .withFileFromPath(".", DOCKERFILE_DIR);
         final GenericContainer<?> container = new GenericContainer<>(image)
                 .withExposedPorts(INTERNAL_DNS_PORT)
                 .waitingFor(Wait.forListeningPorts(INTERNAL_DNS_PORT));
@@ -33,7 +32,6 @@ public class BindContainerFactory {
         container.start();
         return container;
     }
-
 
     public static void deleteBindJournal() throws URISyntaxException, IOException {
         final URL resource = BindContainerFactory.class.getClassLoader().getResource("bind");

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -3,9 +3,7 @@ package com.acme.dns.spark;
 import com.google.common.base.Preconditions;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.InternetProtocol;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
@@ -15,8 +13,6 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Objects;
 
 @Slf4j
@@ -25,8 +21,7 @@ public class BindContainerFactory {
     private static final int INTERNAL_DNS_PORT = 53;
 
     @SneakyThrows
-    public GenericContainer<?> create(int port) {
-        final List<String> bindings = createPortBindings(port);
+    public GenericContainer<?> create() {
 
         final ImageFromDockerfile image = new ImageFromDockerfile("custom-bind-image")
                 .withFileFromPath(".", DOCKERFILE_DIR)
@@ -35,25 +30,10 @@ public class BindContainerFactory {
                 .withExposedPorts(INTERNAL_DNS_PORT)
                 .waitingFor(Wait.forListeningPorts(INTERNAL_DNS_PORT));
 
-        container.setPortBindings(bindings);
         container.start();
         return container;
     }
 
-    /**
-     * Create DNS docker port bindings (CP and UDP) to avoid listening on privileged port under non-privileged user
-     *
-     * @param port non-privileged port to bind service port to,
-     * @return list of port bindings.
-     */
-    private static @NotNull List<String> createPortBindings(final int port) {
-        return Arrays.asList(
-                // UDP: <external>:53/udp
-                String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.UDP),
-                // TCP: <external>:53/tcp
-                String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.TCP)
-        );
-    }
 
     public static void deleteBindJournal() throws URISyntaxException, IOException {
         final URL resource = BindContainerFactory.class.getClassLoader().getResource("bind");

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 @Slf4j
 public class BindContainerFactory {
     private static final Path DOCKERFILE_DIR = Paths.get("src/test/resources");
-    private static final int INTERNAL_DNS_PORT = 53;
+    public static final int INTERNAL_DNS_PORT = 53;
 
     @SneakyThrows
     public GenericContainer<?> create() {
@@ -27,7 +27,7 @@ public class BindContainerFactory {
                 .withFileFromPath(".", DOCKERFILE_DIR);
         final GenericContainer<?> container = new GenericContainer<>(image)
                 .withExposedPorts(INTERNAL_DNS_PORT)
-                .waitingFor(Wait.forListeningPorts(INTERNAL_DNS_PORT));
+                .waitingFor(Wait.forListeningPort());
 
         container.start();
         return container;

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -3,10 +3,11 @@ package com.acme.dns.spark;
 import com.google.common.base.Preconditions;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import org.testcontainers.containers.BindMode;
+import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.InternetProtocol;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -14,39 +15,44 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
 @Slf4j
 public class BindContainerFactory {
-    static final String DOCKER_IMAGE_NAME = "yurkao/dns-bind:9.11";
-    static final DockerImageName DOCKER_IMAGE = DockerImageName.parse(DOCKER_IMAGE_NAME);
-
-    GenericContainer<?> createWin() {
-       return new GenericContainer<>(DOCKER_IMAGE)
-                .withClasspathResourceMapping("bind", "/etc/bind/", BindMode.READ_WRITE);
-    }
-
-    GenericContainer<?> createNix() {
-        return new GenericContainer<>(DOCKER_IMAGE);
-    }
+    private static final Path DOCKERFILE_DIR = Paths.get("src/test/resources");
+    private static final int INTERNAL_DNS_PORT = 53;
 
     @SneakyThrows
-    public GenericContainer<?> create() {
-        final String osName = System.getProperty("os.name");
-        log.info("Current OS name: {}", osName);
-        boolean isWindows = osName.toLowerCase().startsWith("windows");
-        GenericContainer<?> container;
-        if (isWindows) {
-            container = createWin();
-        } else {
-            container = createNix();
-        }
-        final GenericContainer<?> configuredContainer = container
-                .withExposedPorts(53)
-                .waitingFor(Wait.forListeningPort());
+    public GenericContainer<?> create(int port) {
+        final List<String> bindings = createPortBindings(port);
 
-        configuredContainer.start();
-        return configuredContainer;
+        final ImageFromDockerfile image = new ImageFromDockerfile("custom-bind-image")
+                .withFileFromPath(".", DOCKERFILE_DIR)
+                .withFileFromPath("Dockerfile", DOCKERFILE_DIR.resolve("Dockerfile"));
+        final GenericContainer<?> container = new GenericContainer<>(image)
+                .withExposedPorts(INTERNAL_DNS_PORT)
+                .waitingFor(Wait.forListeningPorts(INTERNAL_DNS_PORT));
+
+        container.setPortBindings(bindings);
+        container.start();
+        return container;
+    }
+
+    /**
+     * Create DNS docker port bindings (CP and UDP) to avoid listening on privileged port under ono-privileged user
+     *
+     * @param port non-privileged port to bind service port to,
+     * @return list of port bindings.
+     */
+    private static @NotNull List<String> createPortBindings(final int port) {
+        return Arrays.asList(
+                // UDP: 5353:53/udp
+                String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.UDP),
+                // TCP: 5353:53/tcp
+                String.format("%d:%d/%s", port, INTERNAL_DNS_PORT, InternetProtocol.TCP)
+        );
     }
 
     public static void deleteBindJournal() throws URISyntaxException, IOException {
@@ -74,7 +80,9 @@ public class BindContainerFactory {
         if (log.isTraceEnabled()) {
             log.info("Container logs: {}", container.getLogs());
         }
-        container.stop();
+        if (container != null) {
+            container.stop();
+        }
         deleteBindJournal();
     }
 }

--- a/src/test/java/com/acme/dns/spark/BindContainerFactory.java
+++ b/src/test/java/com/acme/dns/spark/BindContainerFactory.java
@@ -41,7 +41,7 @@ public class BindContainerFactory {
     }
 
     /**
-     * Create DNS docker port bindings (CP and UDP) to avoid listening on privileged port under ono-privileged user
+     * Create DNS docker port bindings (CP and UDP) to avoid listening on privileged port under non-privileged user
      *
      * @param port non-privileged port to bind service port to,
      * @return list of port bindings.

--- a/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
@@ -1,7 +1,6 @@
 package com.acme.dns.spark.read;
 
 import com.acme.dns.spark.BindContainerFactory;
-import com.google.common.base.Preconditions;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
@@ -27,6 +26,7 @@ import static org.assertj.core.api.Assertions.*;
 @Slf4j
 class DnsSourceRelationProviderTest {
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
+    public static final int DNS_PORT = 15353;
     static SparkSession spark;
     static FileSystem fs;
     String checkpoint;
@@ -36,7 +36,6 @@ class DnsSourceRelationProviderTest {
     GenericContainer<?> container;
 
     Map<String, String> options;
-    int xfrPort;
     String xfrHost;
 
     @SneakyThrows
@@ -54,15 +53,15 @@ class DnsSourceRelationProviderTest {
     @SneakyThrows
     @BeforeEach
     void setUp() {
-        container = CONTAINER_FACTORY.create();
-        xfrPort = container.getMappedPort(53);
+        container = CONTAINER_FACTORY.create(DNS_PORT);
+//        xfrPort = container.getMappedPort(DNS_PORT);
         xfrHost = container.getHost();
 
         checkpoint = "./checkpoint-" + UUID.randomUUID();
         outputPath = "./output-" + UUID.randomUUID();
         options = new HashMap<>();
         options.put("server", xfrHost);
-        options.put("port", String.valueOf(xfrPort));
+        options.put("port", String.valueOf(DNS_PORT));
         options.put("zones", "example.acme.,another.zone");
         options.put("organization", "Acme Inc.");
         options.put("xfr", "ixfr");
@@ -77,6 +76,9 @@ class DnsSourceRelationProviderTest {
     }
 
     private void deleteDir(final String location) throws IOException {
+        if (location == null)  {
+            return;
+        }
         final Path path = new Path(location);
         if (!fs.exists(path)) {
             return;
@@ -127,7 +129,7 @@ class DnsSourceRelationProviderTest {
     void sqlBatchRead() {
         assertThatCode(() -> {
             spark.sql( "CREATE TABLE my_table USING dns " +
-                    "OPTIONS (server='" + xfrHost + "', port=" + xfrPort + ", zones='example.acme,another.zone', organization='Acme Inc.')");
+                    "OPTIONS (server='" + xfrHost + "', port=" + DNS_PORT + ", zones='example.acme,another.zone', organization='Acme Inc.')");
             spark.sql("DESC TABLE my_table").show();
             spark.sql("SELECT * FROM my_table").show(false);
         })

--- a/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
@@ -26,11 +26,12 @@ import static org.assertj.core.api.Assertions.*;
 @Slf4j
 class DnsSourceRelationProviderTest {
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
-    public static final int DNS_PORT = 15353;
+    public static final int DNS_PORT = 53;
     static SparkSession spark;
     static FileSystem fs;
     String checkpoint;
     String outputPath;
+    int xfrPort;
 
     @Container
     GenericContainer<?> container;
@@ -53,15 +54,14 @@ class DnsSourceRelationProviderTest {
     @SneakyThrows
     @BeforeEach
     void setUp() {
-        container = CONTAINER_FACTORY.create(DNS_PORT);
-//        xfrPort = container.getMappedPort(DNS_PORT);
+        container = CONTAINER_FACTORY.create();
         xfrHost = container.getHost();
-
+        xfrPort = container.getMappedPort(DNS_PORT);
         checkpoint = "./checkpoint-" + UUID.randomUUID();
         outputPath = "./output-" + UUID.randomUUID();
         options = new HashMap<>();
         options.put("server", xfrHost);
-        options.put("port", String.valueOf(DNS_PORT));
+        options.put("port", String.valueOf(xfrPort));
         options.put("zones", "example.acme.,another.zone");
         options.put("organization", "Acme Inc.");
         options.put("xfr", "ixfr");
@@ -129,7 +129,7 @@ class DnsSourceRelationProviderTest {
     void sqlBatchRead() {
         assertThatCode(() -> {
             spark.sql( "CREATE TABLE my_table USING dns " +
-                    "OPTIONS (server='" + xfrHost + "', port=" + DNS_PORT + ", zones='example.acme,another.zone', organization='Acme Inc.')");
+                    "OPTIONS (server='" + xfrHost + "', port=" + xfrPort + ", zones='example.acme,another.zone', organization='Acme Inc.')");
             spark.sql("DESC TABLE my_table").show();
             spark.sql("SELECT * FROM my_table").show(false);
         })

--- a/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
@@ -31,12 +31,12 @@ class DnsSourceRelationProviderTest {
     static FileSystem fs;
     String checkpoint;
     String outputPath;
-    int xfrPort;
 
     @Container
     GenericContainer<?> container;
 
     Map<String, String> options;
+    int xfrPort;
     String xfrHost;
 
     @SneakyThrows
@@ -76,7 +76,7 @@ class DnsSourceRelationProviderTest {
     }
 
     private void deleteDir(final String location) throws IOException {
-        if (location == null)  {
+        if (location == null) {
             return;
         }
         final Path path = new Path(location);

--- a/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java
@@ -21,12 +21,12 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeoutException;
 
+import static com.acme.dns.spark.BindContainerFactory.INTERNAL_DNS_PORT;
 import static org.assertj.core.api.Assertions.*;
 
 @Slf4j
 class DnsSourceRelationProviderTest {
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
-    public static final int DNS_PORT = 53;
     static SparkSession spark;
     static FileSystem fs;
     String checkpoint;
@@ -56,7 +56,7 @@ class DnsSourceRelationProviderTest {
     void setUp() {
         container = CONTAINER_FACTORY.create();
         xfrHost = container.getHost();
-        xfrPort = container.getMappedPort(DNS_PORT);
+        xfrPort = container.getMappedPort(INTERNAL_DNS_PORT);
         checkpoint = "./checkpoint-" + UUID.randomUUID();
         outputPath = "./output-" + UUID.randomUUID();
         options = new HashMap<>();

--- a/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
+import static com.acme.dns.spark.BindContainerFactory.INTERNAL_DNS_PORT;
 import static com.acme.dns.spark.BindContainerFactory.deleteBindJournal;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
@@ -38,7 +39,6 @@ class DnsSinkRelationProviderTest {
     static final String GENERATED_DATA_VIEW_NAME = "data";
     static final String OUTPUT_TABLE_NAME = "output";
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
-    public static final int DNS_PORT = 53;
 
     static FileSystem fs;
 
@@ -68,7 +68,7 @@ class DnsSinkRelationProviderTest {
         deleteBindJournal();
         container = CONTAINER_FACTORY.create();
         xfrHost = container.getHost();
-        xfrPort = container.getMappedPort(DNS_PORT);
+        xfrPort = container.getMappedPort(INTERNAL_DNS_PORT);
         resolver = new SimpleResolver(xfrHost);
 
         resolver.setTimeout(Duration.of(10, ChronoUnit.SECONDS));

--- a/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
@@ -38,6 +38,7 @@ class DnsSinkRelationProviderTest {
     static final String GENERATED_DATA_VIEW_NAME = "data";
     static final String OUTPUT_TABLE_NAME = "output";
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
+    public static final int DNS_PORT = 15353;
 
     static FileSystem fs;
 
@@ -46,7 +47,6 @@ class DnsSinkRelationProviderTest {
 
     // DNS tst resolver to validate updated records
     SimpleResolver resolver;
-    int xfrPort;
     String xfrHost;
     String checkpoint;
     String dataPath;
@@ -65,14 +65,13 @@ class DnsSinkRelationProviderTest {
     @BeforeEach
     void setUp() throws IOException, URISyntaxException {
         deleteBindJournal();
-        container = CONTAINER_FACTORY.create();
-        xfrPort = container.getMappedPort(53);
+        container = CONTAINER_FACTORY.create(DNS_PORT);
         xfrHost = container.getHost();
         resolver = new SimpleResolver(xfrHost);
 
         resolver.setTimeout(Duration.of(10, ChronoUnit.SECONDS));
         resolver.setTCP(true);
-        resolver.setPort(xfrPort);
+        resolver.setPort(DNS_PORT);
         if(log.isDebugEnabled()) {
             Options.set("verbose");
         }
@@ -105,7 +104,7 @@ class DnsSinkRelationProviderTest {
         assertThatCode(() ->
             data.write().format("dns_update")
                     .option("server", xfrHost)
-                    .option("port", xfrPort)
+                    .option("port", DNS_PORT)
                     .option("timeout", 5)
                     .save()
             )
@@ -125,7 +124,7 @@ class DnsSinkRelationProviderTest {
                     .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (batchDf, batchId) -> batchDf.write()
                             .format("dns_update")
                             .option("server", xfrHost)
-                            .option("port", xfrPort)
+                            .option("port", DNS_PORT)
                             .option("timeout", 5)
                             .save())
                     .start();
@@ -151,7 +150,7 @@ class DnsSinkRelationProviderTest {
                     .select("update")
                     .writeStream().format("dns_update")
                     .option("server", xfrHost)
-                    .option("port", xfrPort)
+                    .option("port", DNS_PORT)
                     .option("timeout", 5)
                     .option("checkpointLocation", checkpoint)
                     .start();
@@ -171,7 +170,7 @@ class DnsSinkRelationProviderTest {
 
         data.createTempView(GENERATED_DATA_VIEW_NAME);
         final String createExpr = "CREATE TABLE " + OUTPUT_TABLE_NAME + " USING dns_update " +
-                "OPTIONS (server='" + xfrHost + "', port=" + xfrPort + ", timeout=10)";
+                "OPTIONS (server='" + xfrHost + "', port=" + DNS_PORT + ", timeout=10)";
         log.info("Create SQL expression: {}", createExpr);
         final String insertExpr = "INSERT INTO " + OUTPUT_TABLE_NAME + " TABLE " + GENERATED_DATA_VIEW_NAME;
         log.info("INSERT SQL expression: {}", insertExpr);

--- a/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
@@ -38,7 +38,7 @@ class DnsSinkRelationProviderTest {
     static final String GENERATED_DATA_VIEW_NAME = "data";
     static final String OUTPUT_TABLE_NAME = "output";
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
-    public static final int DNS_PORT = 15353;
+    public static final int DNS_PORT = 53;
 
     static FileSystem fs;
 
@@ -48,6 +48,7 @@ class DnsSinkRelationProviderTest {
     // DNS tst resolver to validate updated records
     SimpleResolver resolver;
     String xfrHost;
+    int xfrPort;
     String checkpoint;
     String dataPath;
 
@@ -65,13 +66,14 @@ class DnsSinkRelationProviderTest {
     @BeforeEach
     void setUp() throws IOException, URISyntaxException {
         deleteBindJournal();
-        container = CONTAINER_FACTORY.create(DNS_PORT);
+        container = CONTAINER_FACTORY.create();
         xfrHost = container.getHost();
+        xfrPort = container.getMappedPort(DNS_PORT);
         resolver = new SimpleResolver(xfrHost);
 
         resolver.setTimeout(Duration.of(10, ChronoUnit.SECONDS));
         resolver.setTCP(true);
-        resolver.setPort(DNS_PORT);
+        resolver.setPort(xfrPort);
         if(log.isDebugEnabled()) {
             Options.set("verbose");
         }
@@ -104,7 +106,7 @@ class DnsSinkRelationProviderTest {
         assertThatCode(() ->
             data.write().format("dns_update")
                     .option("server", xfrHost)
-                    .option("port", DNS_PORT)
+                    .option("port", xfrPort)
                     .option("timeout", 5)
                     .save()
             )
@@ -124,7 +126,7 @@ class DnsSinkRelationProviderTest {
                     .foreachBatch((VoidFunction2<Dataset<Row>, Long>) (batchDf, batchId) -> batchDf.write()
                             .format("dns_update")
                             .option("server", xfrHost)
-                            .option("port", DNS_PORT)
+                            .option("port", xfrPort)
                             .option("timeout", 5)
                             .save())
                     .start();
@@ -150,7 +152,7 @@ class DnsSinkRelationProviderTest {
                     .select("update")
                     .writeStream().format("dns_update")
                     .option("server", xfrHost)
-                    .option("port", DNS_PORT)
+                    .option("port", xfrPort)
                     .option("timeout", 5)
                     .option("checkpointLocation", checkpoint)
                     .start();
@@ -170,7 +172,7 @@ class DnsSinkRelationProviderTest {
 
         data.createTempView(GENERATED_DATA_VIEW_NAME);
         final String createExpr = "CREATE TABLE " + OUTPUT_TABLE_NAME + " USING dns_update " +
-                "OPTIONS (server='" + xfrHost + "', port=" + DNS_PORT + ", timeout=10)";
+                "OPTIONS (server='" + xfrHost + "', port=" + xfrPort + ", timeout=10)";
         log.info("Create SQL expression: {}", createExpr);
         final String insertExpr = "INSERT INTO " + OUTPUT_TABLE_NAME + " TABLE " + GENERATED_DATA_VIEW_NAME;
         log.info("INSERT SQL expression: {}", insertExpr);

--- a/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java
@@ -45,7 +45,7 @@ class DnsSinkRelationProviderTest {
     @Container
     GenericContainer<?> container;
 
-    // DNS tst resolver to validate updated records
+    // DNS test resolver to validate updated records
     SimpleResolver resolver;
     String xfrHost;
     int xfrPort;

--- a/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 class DnsUpdateTest {
+    public static final int DNS_PORT = 15353;
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
 
     @Container
@@ -30,7 +31,7 @@ class DnsUpdateTest {
     @SneakyThrows
     @BeforeEach
     void setUp() {
-        container = CONTAINER_FACTORY.create();
+        container = CONTAINER_FACTORY.create(DNS_PORT);
     }
 
     @AfterEach

--- a/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
@@ -17,12 +17,12 @@ import java.sql.Timestamp;
 import java.util.Collections;
 import java.util.Set;
 
+import static com.acme.dns.spark.BindContainerFactory.INTERNAL_DNS_PORT;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 class DnsUpdateTest {
-    public static final int DNS_PORT = 53;
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
 
     @Container
@@ -49,7 +49,7 @@ class DnsUpdateTest {
         change.setIp("127.0.0.1");
         change.setFqdn("foo." + zoneName);
         change.setTtl(1234);
-        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getMappedPort(DNS_PORT));
+        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getMappedPort(INTERNAL_DNS_PORT));
         final Name zone = Name.fromString(zoneName);
         final Set<DnsRecordUpdate> updates = Collections.singleton(change);
         assertThatCode(() -> dnsUpdate.update(zone, updates))
@@ -67,7 +67,7 @@ class DnsUpdateTest {
         change.setIp("127.0.0.1");
         change.setFqdn("foo." + zoneName);
         change.setTtl(1234);
-        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getFirstMappedPort());
+        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getMappedPort(INTERNAL_DNS_PORT));
         final Name zone = Name.fromString(zoneName);
         final Set<DnsRecordUpdate> updates = Collections.singleton(change);
         assertThatThrownBy(() ->dnsUpdate.update(zone, updates))

--- a/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
+++ b/src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 class DnsUpdateTest {
-    public static final int DNS_PORT = 15353;
+    public static final int DNS_PORT = 53;
     static final BindContainerFactory CONTAINER_FACTORY = new BindContainerFactory();
 
     @Container
@@ -31,7 +31,7 @@ class DnsUpdateTest {
     @SneakyThrows
     @BeforeEach
     void setUp() {
-        container = CONTAINER_FACTORY.create(DNS_PORT);
+        container = CONTAINER_FACTORY.create();
     }
 
     @AfterEach
@@ -49,7 +49,7 @@ class DnsUpdateTest {
         change.setIp("127.0.0.1");
         change.setFqdn("foo." + zoneName);
         change.setTtl(1234);
-        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getFirstMappedPort());
+        final DnsUpdate dnsUpdate = new DnsUpdate(container.getHost(), container.getMappedPort(DNS_PORT));
         final Name zone = Name.fromString(zoneName);
         final Set<DnsRecordUpdate> updates = Collections.singleton(change);
         assertThatCode(() -> dnsUpdate.update(zone, updates))

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu/bind9:edge
+FROM ubuntu/bind9:9.18-22.04
 ADD bind /etc/bind
 RUN chmod 1777 /etc/bind

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu/bind9:9.18-22.04
+FROM ubuntu/bind9:9.18-22.04_edge
 ADD bind /etc/bind
 RUN chmod 1777 /etc/bind

--- a/src/test/resources/Dockerfile
+++ b/src/test/resources/Dockerfile
@@ -1,3 +1,3 @@
-FROM internetsystemsconsortium/bind9:9.21
+FROM ubuntu/bind9:edge
 ADD bind /etc/bind
 RUN chmod 1777 /etc/bind

--- a/src/test/resources/bind/named.conf.local
+++ b/src/test/resources/bind/named.conf.local
@@ -3,7 +3,7 @@ acl friendly {
         127.0.0.1/32;           // localhost
         192.168.0.0/16;             // internal
         10.0.0.0/8;             // internal
-        172.0.0.0/8;
+        172.17.0.0/16;           // Docker default bridge network
 };
 zone "example.acme" {
      type master;

--- a/src/test/resources/bind/named.conf.local
+++ b/src/test/resources/bind/named.conf.local
@@ -3,7 +3,7 @@ acl friendly {
         127.0.0.1/32;           // localhost
         192.168.0.0/16;             // internal
         10.0.0.0/8;             // internal
-        172.17.0.2/8;
+        172.17.0.0/16;
 };
 zone "example.acme" {
      type master;

--- a/src/test/resources/bind/named.conf.local
+++ b/src/test/resources/bind/named.conf.local
@@ -3,7 +3,7 @@ acl friendly {
         127.0.0.1/32;           // localhost
         192.168.0.0/16;             // internal
         10.0.0.0/8;             // internal
-        172.17.0.0/16;
+        172.0.0.0/8;
 };
 zone "example.acme" {
      type master;


### PR DESCRIPTION
## Pull request overview

This PR updates the test infrastructure to support ARM64 architecture by switching to an Ubuntu-based BIND9 Docker image and refactoring the port binding mechanism to use fixed non-privileged ports.

**Key Changes:**
- Replaced Docker image from `internetsystemsconsortium/bind9:9.21` to `ubuntu/bind9:edge` for ARM64 compatibility
- Refactored `BindContainerFactory` to use explicit port bindings (port 15353) instead of OS-specific container creation and dynamic port mapping
- Updated BIND ACL configuration to use a more specific network range (172.17.0.0/16 instead of 172.17.0.2/8)

### Reviewed changes

Copilot reviewed 6 out of 6 changed files in this pull request and generated 9 comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/test/resources/Dockerfile | Changed base image from internetsystemsconsortium/bind9:9.21 to ubuntu/bind9:edge for ARM64 support |
| src/test/resources/bind/named.conf.local | Updated ACL IP range from 172.17.0.2/8 to 172.17.0.0/16 for Docker network compatibility |
| src/test/java/com/acme/dns/spark/BindContainerFactory.java | Refactored container creation to build custom image, use fixed port bindings, and removed OS-specific logic |
| src/test/java/com/acme/dns/spark/write/DnsUpdateTest.java | Added DNS_PORT constant and updated container creation to use fixed port |
| src/test/java/com/acme/dns/spark/write/DnsSinkRelationProviderTest.java | Replaced dynamic port mapping with DNS_PORT constant and removed xfrPort field |
| src/test/java/com/acme/dns/spark/read/DnsSourceRelationProviderTest.java | Replaced dynamic port mapping with DNS_PORT constant, removed xfrPort field and unused import, added null check in deleteDir |
</details>

