### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/yurkao/spark-dns/security/code-scanning/3](https://github.com/yurkao/spark-dns/security/code-scanning/3)

To fix the problem, we need to add a `permissions` block to the workflow to follow the principle of least privilege. Since the workflow only checks out code and builds it, the only required permission is `contents: read`. The `permissions` block can be placed at the root of the workflow YAML file, just below the `name` declaration and before the `on` or `jobs` sections. No imports or special methods are needed, just a small YAML change. We will insert the block:

```yaml
permissions:
  contents: read
```

directly after the workflow name.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
